### PR TITLE
Set TLSConfig for Redis client of lock

### DIFF
--- a/v1/locks/redis/redis.go
+++ b/v1/locks/redis/redis.go
@@ -35,9 +35,10 @@ func New(cnf *config.Config, addrs []string, db, retries int) Lock {
 	}
 
 	ropt := &redis.UniversalOptions{
-		Addrs:    addrs,
-		DB:       db,
-		Password: password,
+		Addrs:     addrs,
+		DB:        db,
+		Password:  password,
+		TLSConfig: cnf.TLSConfig,
 	}
 	if cnf.Redis != nil {
 		ropt.MasterName = cnf.Redis.MasterName

--- a/v2/locks/redis/redis.go
+++ b/v2/locks/redis/redis.go
@@ -35,9 +35,10 @@ func New(cnf *config.Config, addrs []string, db, retries int) Lock {
 	}
 
 	ropt := &redis.UniversalOptions{
-		Addrs:    addrs,
-		DB:       db,
-		Password: password,
+		Addrs:     addrs,
+		DB:        db,
+		Password:  password,
+		TLSConfig: cnf.TLSConfig,
 	}
 	if cnf.Redis != nil {
 		ropt.MasterName = cnf.Redis.MasterName


### PR DESCRIPTION
# Purposes

When the Redis client of lock is initialized, TLSConfig is not set, which will cause a connection issue if the Redis server requires TLS. This PR fixes that issue.

# Changes

Set `TLSConfig` in the options passed into `redis.NewUniversalClient()`.